### PR TITLE
Fix punctuation deletion indices when crop excludes earlier punctuation

### DIFF
--- a/voxtream/dataset.py
+++ b/voxtream/dataset.py
@@ -210,10 +210,9 @@ class TrainDataset(Dataset):
         tokens = np.array(tokens).astype(self.dtype)
 
         mask = (ins_idx > min_idx) & (ins_idx <= max_idx + 1)
-        phoneme_sequence = np.insert(
-            phoneme_sequence, ins_idx[mask] - min_idx, tokens[mask]
-        )
-        punct_del_idx = punct_del_idx[mask] - min_idx + 1  # <BOS>
+        ins_in_slice = ins_idx[mask] - min_idx
+        phoneme_sequence = np.insert(phoneme_sequence, ins_in_slice, tokens[mask])
+        punct_del_idx = (ins_in_slice + np.arange(mask.sum())).astype(self.dtype) + 1  # <BOS>
 
         # Add prompt <UNK> phone tokens
         phoneme_sequence = np.concatenate(


### PR DESCRIPTION
## Summary

`dataset.py:213` mixes coordinate systems when computing punctuation
deletion indices, causing `remove_punctuation` to target wrong positions
whenever the random crop window excludes punctuation that appears earlier
in the utterance. This affects ~95% of Emilia and ~94% of HiFiTTS2
training samples.

## The bug

`punct_del_idx[mask]` is in the post-insertion coordinate system of the
full utterance, but `min_idx` is in the non-punctuated coordinate system.
When punctuation exists before the crop, they diverge by exactly the
count of those preceding marks.

## Fix

Recompute post-insertion positions from `ins_idx` within the sliced
sequence:

```python
ins_in_slice = ins_idx[mask] - min_idx
punct_del_idx = (ins_in_slice + np.arange(mask.sum())).astype(self.dtype) + 1
```

This makes the result independent of any punctuation outside the crop
window, and removes the dependency on the pre-computed `del_idx`.