### PR TITLE
Fix prompt audio Path loading

### DIFF
--- a/voxtream/utils/generator/prompt.py
+++ b/voxtream/utils/generator/prompt.py
@@ -135,7 +135,7 @@ def prepare_prompt(
             device, dtype=dtype
         )
     else:
-        waveform, orig_sr = torchaudio.load(prompt_audio_path)
+        waveform, orig_sr = torchaudio.load(str(prompt_audio_path))
         if waveform.shape[0] != 1:
             logger.warning(
                 f"Prompt audio has {waveform.shape[0]} channels; converting to mono by averaging."


### PR DESCRIPTION
## Summary
- Cast `prompt_audio_path` to `str` before passing it to `torchaudio.load`.
- Fixes a macOS/sox backend runtime crash when `prompt_audio_path` is a `pathlib.Path`.

## Context
With `torchaudio==2.4.0`, the sox backend rejects `pathlib.Path` values at the C++ boundary:

```text
torchaudio_sox::load_audio_file() Expected a value of type 'str' for argument '_0' but instead found type 'PosixPath'
```

The patched call keeps the existing behavior but passes the filesystem path in the format the backend accepts.

## Verification
- `python3 -m py_compile voxtream/utils/generator/prompt.py`
- Confirmed `torchaudio.load(Path(...))` fails with the error above.
- Confirmed `torchaudio.load(str(path))` succeeds.
- Ran `.venv/bin/python -m pytest tests -q`; the prompt-loading crash is resolved and execution reaches generation. The existing regression test still fails on an unrelated fixture shape mismatch: generated `(38400,)` vs reference `(46080,)`.